### PR TITLE
chore(test,ci): fix x/cw-hooks wasm embed, codeql noise, release dispatch

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -14,3 +14,12 @@ paths-ignore:
   - "**/*_test.go"
   - "**/testutil/**"
   - "**/mocks/**"
+
+# CodeQL's paths-ignore only filters source files; for compiled languages like
+# Go, alerts that originate from imports in already-compiled generated code
+# (api/**/*.pulsar.go) still surface unless the rule is filtered explicitly.
+# The crypto-com/cosmos-sdk-codeql/sensitive-import query is a known false
+# positive on cosmos-sdk pulsar/protobuf bindings, so drop it globally.
+query-filters:
+  - exclude:
+      id: crypto-com/cosmos-sdk-codeql/sensitive-import

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -33,17 +33,37 @@ jobs:
       - name: Build repo_config JSON
         id: build_repo_config
         env:
-          GITHUB_EVENT_RELEASE_TAG: ${{ github.event.release.tag_name }}
+          # Resolve the tag for both `release: released` (uses release.tag_name)
+          # and `push: tags` (only ref_name is set). ref_name is the tag in
+          # both cases, but we keep the explicit fallback for clarity.
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
         run: |
-          printf '[\n  {"name": "safrochain", "repo": "%s", "rev": "%s", "dir": "%s", "exclude_mods": [], "is_main": true},\n  {"name": "cosmos-sdk", "repo": "%s", "rev": "%s", "dir": "%s", "exclude_mods": ["reflection", "autocli"], "is_main": false},\n  {"name": "wasmd", "repo": "%s", "rev": "%s", "dir": "%s", "exclude_mods": [], "is_main": false},\n  {"name": "cometbft", "repo": "%s", "rev": "%s", "dir": "%s", "exclude_mods": [], "is_main": false},\n  {"name": "ibc-go", "repo": "%s", "rev": "%s", "dir": "%s", "exclude_mods": [], "is_main": false},\n  {"name": "ics23", "repo": "%s", "rev": "%s", "dir": "%s", "exclude_mods": [], "is_main": false}\n]\n' \
-            "$SAFROCHAIN_REPO" "$GITHUB_EVENT_RELEASE_TAG" "$SAFROCHAIN_DIR" \
-            "$COSMOS_SDK_REPO" "$COSMOS_SDK_REV" "$COSMOS_SDK_DIR" \
-            "$WASMD_REPO" "$WASMD_REV" "$WASMD_DIR" \
-            "$COMETBFT_REPO" "$COMETBFT_REV" "$COMETBFT_DIR" \
-            "$IBC_GO_REPO" "$IBC_GO_REV" "$IBC_GO_DIR" \
-            "$ICS23_REPO" "$ICS23_REV" "$ICS23_DIR" > repo_config.json
+          jq -c -n \
+            --arg safrochain_repo  "$SAFROCHAIN_REPO"  --arg safrochain_rev "$RELEASE_TAG"   --arg safrochain_dir "$SAFROCHAIN_DIR" \
+            --arg cosmos_sdk_repo  "$COSMOS_SDK_REPO"  --arg cosmos_sdk_rev "$COSMOS_SDK_REV" --arg cosmos_sdk_dir "$COSMOS_SDK_DIR" \
+            --arg wasmd_repo       "$WASMD_REPO"       --arg wasmd_rev      "$WASMD_REV"     --arg wasmd_dir      "$WASMD_DIR" \
+            --arg cometbft_repo    "$COMETBFT_REPO"    --arg cometbft_rev   "$COMETBFT_REV"  --arg cometbft_dir   "$COMETBFT_DIR" \
+            --arg ibc_go_repo      "$IBC_GO_REPO"      --arg ibc_go_rev     "$IBC_GO_REV"    --arg ibc_go_dir     "$IBC_GO_DIR" \
+            --arg ics23_repo       "$ICS23_REPO"       --arg ics23_rev      "$ICS23_REV"     --arg ics23_dir      "$ICS23_DIR" \
+            '[
+              {name: "safrochain", repo: $safrochain_repo, rev: $safrochain_rev, dir: $safrochain_dir, exclude_mods: [],                          is_main: true},
+              {name: "cosmos-sdk", repo: $cosmos_sdk_repo, rev: $cosmos_sdk_rev, dir: $cosmos_sdk_dir, exclude_mods: ["reflection", "autocli"], is_main: false},
+              {name: "wasmd",      repo: $wasmd_repo,      rev: $wasmd_rev,      dir: $wasmd_dir,      exclude_mods: [],                          is_main: false},
+              {name: "cometbft",   repo: $cometbft_repo,   rev: $cometbft_rev,   dir: $cometbft_dir,   exclude_mods: [],                          is_main: false},
+              {name: "ibc-go",     repo: $ibc_go_repo,     rev: $ibc_go_rev,     dir: $ibc_go_dir,     exclude_mods: [],                          is_main: false},
+              {name: "ics23",      repo: $ics23_repo,      rev: $ics23_rev,      dir: $ics23_dir,      exclude_mods: [],                          is_main: false}
+            ]' > repo_config.json
+          echo "::group::repo_config.json"
           cat repo_config.json
-          echo "json=$(cat repo_config.json)" >> $GITHUB_OUTPUT
+          echo "::endgroup::"
+          # repo_config.json is single-line (jq -c) but use heredoc for
+          # safety in case the JSON ever contains a literal newline.
+          {
+            echo 'json<<__SAFRO_JSON_EOF__'
+            cat repo_config.json
+            echo '__SAFRO_JSON_EOF__'
+          } >> "$GITHUB_OUTPUT"
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Dispatch release event with repo_config
@@ -54,8 +74,8 @@ jobs:
           event-type: safrochain-release
           client-payload: |
             {
-              "is_draft": "${{ github.event.release.draft }}",
-              "is_prerelease": "${{ github.event.release.prerelease }}",
-              "release_tag": "${{ github.event.release.tag_name }}",
-              "repo_config": "${{ steps.build_repo_config.outputs.json }}"
+              "is_draft": "${{ github.event.release.draft || false }}",
+              "is_prerelease": "${{ github.event.release.prerelease || false }}",
+              "release_tag": "${{ steps.build_repo_config.outputs.release_tag }}",
+              "repo_config": ${{ steps.build_repo_config.outputs.json }}
             }

--- a/x/cw-hooks/keeper/keeper_test.go
+++ b/x/cw-hooks/keeper/keeper_test.go
@@ -1,12 +1,13 @@
 package keeper_test
 
 import (
-	_ "embed"
 	"testing"
 
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/stretchr/testify/suite"
+
+	_ "embed"
 
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"

--- a/x/cw-hooks/keeper/keeper_test.go
+++ b/x/cw-hooks/keeper/keeper_test.go
@@ -1,7 +1,7 @@
 package keeper_test
 
 import (
-	"embed"
+	_ "embed"
 	"testing"
 
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
@@ -16,8 +16,7 @@ import (
 	"github.com/Safrochain_Org/safrochain/x/cw-hooks/types"
 )
 
-var _ = embed.FS{}
-
+//go:embed testdata/juno_staking_hooks_example.wasm
 var wasmContract []byte
 
 type KeeperTestSuite struct {


### PR DESCRIPTION
## Why

Three pre-existing CI/quality bugs surfaced after the v0.2.1 merge:

1. **`build` workflow has been failing on every push since at least Apr 26** because `TestKeeperTestSuite/TestUnRegisterContracts` errors with `code bytes is required: empty: invalid request`. Root cause: `x/cw-hooks/keeper/keeper_test.go` declared `var wasmContract []byte` but the `//go:embed` directive was never written. The `embed` package was imported and a dummy `var _ = embed.FS{}` line kept the import compiling, but the contract bytes were always empty. Verified by comparing with `x/feeshare/keeper/keeper_test.go` and `x/feepay/keeper/keeper_test.go`, which both use the standard `_ "embed"` + `//go:embed testdata/*.wasm` pattern.

2. **26 sensitive-import false positives** kept piling up on Code scanning. The `crypto-com/cosmos-sdk-codeql/sensitive-import` query fires on every protobuf import inside `api/**/*.pulsar.go`. CodeQL's `paths-ignore` only suppresses source-file extraction; for the Go extractor, alerts on imports inside already-compiled generated code still surface. The 26 existing alerts have been dismissed manually; this PR adds `query-filters` so they don't come back.

3. **`Dispatch Release to safrochain-std` workflow has failed on every release since v0.1.0** with `Invalid format ' {\"name\": ...`. Root cause: the step writes a multi-line JSON to `$GITHUB_OUTPUT` via `echo \"json=\$(cat repo_config.json)\"`, which is not a valid GitHub Actions output assignment. Multi-line values must use the heredoc form. The `client-payload` was also wrapping the JSON in `\"...\"`, producing invalid double-quoted JSON, and the workflow used `github.event.release.tag_name` which is empty on `push: tags` triggers.

## What

### `x/cw-hooks/keeper/keeper_test.go`
- `\"embed\"` -> `_ \"embed\"`
- delete the `var _ = embed.FS{}` placeholder
- add `//go:embed testdata/juno_staking_hooks_example.wasm` above `var wasmContract []byte`

### `.github/codeql/codeql-config.yml`
Add a `query-filters` block:

\`\`\`yaml
query-filters:
  - exclude:
      id: crypto-com/cosmos-sdk-codeql/sensitive-import
\`\`\`

### `.github/workflows/release-dispatch.yml`
- Replace the multi-line `printf` + `echo \"json=\$(cat ...)\" >> \$GITHUB_OUTPUT` with `jq -c -n` (single-line compact JSON) emitted through the heredoc form (`json<<__SAFRO_JSON_EOF__ ... __SAFRO_JSON_EOF__`).
- Resolve `RELEASE_TAG` from `github.event.release.tag_name || github.ref_name` so both \`release: released\` and \`push: tags\` triggers populate the safrochain rev correctly.
- Inject `repo_config` into the `client-payload` as raw JSON (was previously double-quoted string-of-JSON, which produced invalid JSON whenever the inner array contained quotes -- i.e. always).
- Default missing release fields (`is_draft`, `is_prerelease`) to `false` for the `push: tags` case.

## Verification

\`\`\`text
$ go test -count=1 -run TestKeeperTestSuite/TestUnRegisterContracts ./x/cw-hooks/keeper/
ok  	github.com/Safrochain_Org/safrochain/x/cw-hooks/keeper	1.724s

$ go test -count=1 ./x/cw-hooks/keeper/
ok  	github.com/Safrochain_Org/safrochain/x/cw-hooks/keeper	1.557s

$ go build ./...
ok

$ go vet ./x/cw-hooks/...
clean

$ python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/release-dispatch.yml'))\"
ok
\`\`\`

The release-dispatch fix is exercised on the next \`v*.*.*\` tag push or release publication. The downstream consumer (\`Safrochain_Org/safrochain-std\`) will now receive a valid \`repo_config\` payload as a JSON array (was previously an unparseable double-quoted string-of-JSON; given every prior release dispatch failed, no working contract was broken).
