### PR TITLE
release: mirror v0.2.2 — default minimum gas price 100000 usaf

### DIFF
--- a/cmd/safrochaind/cmd/root.go
+++ b/cmd/safrochaind/cmd/root.go
@@ -226,7 +226,7 @@ func initAppConfig() (string, any) {
 	// server config.
 	srvCfg := serverconfig.DefaultConfig()
 	srvCfg.MinGasPrices = strings.Join(
-		[]string{"0.075" + sdk.DefaultBondDenom}, ",")
+		[]string{"100000" + sdk.DefaultBondDenom}, ",")
 
 	customAppConfig := CustomAppConfig{
 		Config: *srvCfg,


### PR DESCRIPTION
## Summary

Mirrors the **v0.2.2** release from [`danbaruka/safrochain-node`](https://github.com/danbaruka/safrochain-node) into this repository.

- Sets the chain default minimum gas price to **100000 usaf** (0.1 SAF per gas unit) in `cmd/safrochaind/cmd/root.go`
- Tag `v0.2.2` already exists on the fork: https://github.com/danbaruka/safrochain-node/releases/tag/v0.2.2

`upstream/main` already includes everything through **v0.2.1** and #24; this PR adds the single commit that constitutes **v0.2.2**.

## After merge

1. Tag **`v0.2.2`** on the merge commit:
   ```bash
   git tag -a v0.2.2 -m "Release v0.2.2: chain default minimum gas price 100000 usaf (0.1 SAF per gas unit)."
   git push origin v0.2.2
   ```
2. Publish a GitHub Release from that tag (optional but recommended for visibility and release notes).

## Test plan

- [ ] CI passes
- [ ] Verify default min gas price in `cmd/safrochaind/cmd/root.go` matches fork `v0.2.2`
- [ ] After merge, create `v0.2.2` tag on `Safrochain-Org/safrochain-node`
