### PR TITLE
feat: tune default min gas price from 100000usaf to 0.05usaf

### DIFF
--- a/cmd/safrochaind/cmd/root.go
+++ b/cmd/safrochaind/cmd/root.go
@@ -226,7 +226,7 @@ func initAppConfig() (string, any) {
 	// server config.
 	srvCfg := serverconfig.DefaultConfig()
 	srvCfg.MinGasPrices = strings.Join(
-		[]string{"100000" + sdk.DefaultBondDenom}, ",")
+		[]string{"0.05" + sdk.DefaultBondDenom}, ",")
 
 	customAppConfig := CustomAppConfig{
 		Config: *srvCfg,


### PR DESCRIPTION
## Summary

Follow-up to #25, which set the default `min-gas-prices` to `100000usaf` per gas unit. At that rate, a typical `MsgSend` (≈80 000 gas) costs **8 000 SAF** — more than any community validator's self-stake. This PR drops the default to **`0.05usaf`** per gas, putting per-tx user costs in the cent range while still meaningfully feeding validator fee revenue.

## Per-tx cost at the new default

| Message | Gas | Fee in SAF (1 SAF = 1e6 usaf) |
| :--- | ---: | ---: |
| `MsgSend` | 80 000 | ~ 0.004 SAF |
| `MsgDelegate` | 200 000 | ~ 0.010 SAF |
| IBC `MsgTransfer` | 200 000 | ~ 0.010 SAF |
| Wasm contract call | 1 000 000 | ~ 0.050 SAF |

## Notes

- One-line change in [cmd/safrochaind/cmd/root.go](https://github.com/Safrochain-Org/safrochain-node/blob/main/cmd/safrochaind/cmd/root.go#L228).
- Operators can still override per-host via `app.toml` `minimum-gas-prices` — this only touches the default that ships with a fresh `safrochaind init`.
- Tested locally on `safrochain-1` (8 validators, height-1 boot via `InitGenesis` is unaffected; this only changes the default Server config for newly-initialised homes).

## Test plan

- [ ] CI green
- [ ] Manually verify `safrochaind init` on a fresh home writes `minimum-gas-prices = "0.05usaf"` to the generated `app.toml`
- [ ] Confirm a `MsgSend` at default fees is accepted on a local devnet