### PR TITLE
docs: fix README clone URL (points to personal fork)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Safrochain is a community-first blockchain built using the Cosmos SDK. This repo
 - GCC (for protobuf & Wasm)
 
 ```bash
-git clone https://github.com/danbaruka/safrochain-node.git
+git clone https://github.com/Safrochain-Org/safrochain-node.git
 cd safrochain-node
 make install
 ```


### PR DESCRIPTION
Fixes #32: Changed the git clone URL from personal repo danbaruka/safrochain-node to organization repo Safrochain-Org/safrochain-node