### PR TITLE
chore: update CODEOWNERS to Safrochain maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,26 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
+#
+# Each line specifies a file pattern followed by one or more owners.
+# Order matters: the last matching pattern takes precedence.
 
-* @JakeHartnell @dimiandre @niilptr @vexxvakan
+# Default owners for everything
+*                       @danbaruka @elielnfinic
+
+# Custom modules
+/x/clock/               @danbaruka @elielnfinic
+/x/cw-hooks/            @danbaruka @elielnfinic
+/x/drip/                @danbaruka @elielnfinic
+/x/feepay/              @danbaruka @elielnfinic
+/x/feeshare/            @danbaruka @elielnfinic
+/x/globalfee/           @danbaruka @elielnfinic
+/x/tokenfactory/        @danbaruka @elielnfinic
+/x/wrappers/            @danbaruka @elielnfinic
+
+# App wiring and consensus
+/app/                   @danbaruka @elielnfinic
+
+# Build / CI / release
+/.github/               @danbaruka @elielnfinic
+
+# Smart-contract / wasm code
+/wasmbindings/          @danbaruka @elielnfinic


### PR DESCRIPTION
## Summary

Closes #36

The current CODEOWNERS file listed external handles (`@JakeHartnell`, `@dimiandre`, `@niilptr`, `@vexxvakan`) that are not Safrochain organization members — a leftover from the upstream fork.

## Changes

- Replaced the wildcard line with `@danbaruka` and `@elielnfinic` as default owners (the two most active contributors on this repo)
- Added per-module ownership rules for each `x/` custom module, `/app/`, `/.github/`, and `/wasmbindings/`
- This ensures PR review requests reach Safrochain maintainers and not external users

## Verification

- [x] No external handles referenced
- [x] All paths match actual directories in the repository
