### PR TITLE
chore: update CODEOWNERS to Safrochain maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
-# CODEOWNERS: https://help.github.com/articles/about-codeowners/
+# Code Owners
+# Auto-generated: Safrochain organization maintainers
 
-* @JakeHartnell @dimiandre @niilptr @vexxvakan
+* @danbaruka


### PR DESCRIPTION
Closes #42

Updates .github/CODEOWNERS to point to current Safrochain organization maintainers instead of external handles.