### PR TITLE
docs: add CHANGELOG.md following Keep a Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- End-to-end x/tokenfactory minting example (#39)
+- CosmWasm contract examples and deploy walkthrough (#38)
+- Per-module README for each `x/` custom module (#31)
+- Self-documenting `help` Makefile target (#34)
+- GitHub issue templates and PR template (#30)
+- `CODE_OF_CONDUCT.md` (Contributor Covenant) (#29)
+- `CONTRIBUTING.md` with comprehensive contributing directives (#28, #27)
+- GitHub Discussions enabled (#45)
+- CHANGELOG.md following Keep a Changelog (#37)
+
+### Changed
+- Updated CODEOWNERS to Safrochain organization maintainers (#36)
+- Replaced old issue templates with YAML form-builder templates (#44)
+
+### Security
+- Bumped `cosmossdk.io/log` to 1.6.1 (#22)
+- Bumped `github.com/cosmos/cosmos-db` to 1.1.3 (#1)


### PR DESCRIPTION
Closes #37

Adds CHANGELOG.md following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.