### PR TITLE
chore: update CODEOWNERS — replace upstream handles with Safrochain org members

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,30 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
+#
+# Each line is a file pattern followed by one or more owners.
+# Order matters: the last matching pattern has the most precedence.
 
-* @JakeHartnell @dimiandre @niilptr @vexxvakan
+# Default: @danbaruka is the sole org member as of this writing
+*                       @danbaruka
+
+# Custom modules - maintained by core
+/x/clock/               @danbaruka
+/x/cw-hooks/            @danbaruka
+/x/drip/                @danbaruka
+/x/feepay/              @danbaruka
+/x/feeshare/            @danbaruka
+/x/globalfee/           @danbaruka
+/x/tokenfactory/        @danbaruka
+/x/wrappers/            @danbaruka
+
+# App wiring and consensus
+/app/                   @danbaruka
+
+# Build, CI/CD, and tooling
+/.github/               @danbaruka
+/scripts/               @danbaruka
+/Makefile               @danbaruka
+/Makefile.inc           @danbaruka
+
+# Documentation
+/README.md              @danbaruka
+/docs/                  @danbaruka


### PR DESCRIPTION
## Summary

The current `.github/CODEOWNERS` references external handles (`@JakeHartnell`, `@dimiandre`, `@niilptr`, `@vexxvakan`) that are not Safrochain organization members — likely a leftover from the upstream fork. Every PR opened against this repo auto-requests reviews from people outside the org.

## Changes

- Replaced all upstream handles with `@danbaruka` (sole current Safrochain-Org member)
- Added granular path rules for custom modules (`x/clock`, `x/cw-hooks`, `x/drip`, `x/feepay`, `x/feeshare`, `x/globalfee`, `x/tokenfactory`, `x/wrappers`), the app layer, CI/CD files, and docs
- Each path has a clear comment explaining the scope

## Related issue

Closes #36