### PR TITLE
fix: update CODEOWNERS — replace upstream fork handles with Safrochain maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,31 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
+#
+# Each line is a file pattern followed by one or more owners.
+# Order matters: last matching pattern takes precedence.
 
-* @JakeHartnell @dimiandre @niilptr @vexxvakan
+# Default owners for everything
+*                       @danbaruka @elielnfinic
+
+# Custom x/ modules
+/x/clock/               @danbaruka @elielnfinic
+/x/cw-hooks/            @danbaruka @elielnfinic
+/x/drip/                @danbaruka @elielnfinic
+/x/feepay/              @danbaruka @elielnfinic
+/x/feeshare/            @danbaruka @elielnfinic
+/x/globalfee/           @danbaruka @elielnfinic
+/x/tokenfactory/        @danbaruka @elielnfinic
+/x/wrappers/            @danbaruka @elielnfinic
+
+# App wiring and consensus
+/app/                   @danbaruka @elielnfinic
+
+# Build / CI / release
+/.github/               @danbaruka
+/Makefile*              @danbaruka @elielnfinic
+/Dockerfile*            @danbaruka @elielnfinic
+/goreleaser.yml         @danbaruka
+
+# Documentation
+/docs/                  @danbaruka @elielnfinic
+/README.md              @danbaruka
+/CHANGELOG.md           @danbaruka


### PR DESCRIPTION
## Summary

Closes #36

The current `.github/CODEOWNERS` contains handles (`@JakeHartnell`, `@dimiandre`, `@niilptr`, `@vexxvakan`) that belong to individuals outside the Safrochain-Org organization — a leftover from the upstream fork. This means every PR auto-requests reviews from people who are not Safrochain maintainers, which is noisy for them and means no auto-request goes to the actual team.

## Changes

- Replaced stale external handles with `@danbaruka` and `@elielnfinic` (current maintainers/contributors)
- Added granular directory-level rules for `x/` custom modules, `/app`, `/.github`, `/docs`, `Makefile`, `Dockerfile`, `goreleaser.yml`, etc.
- Retained the wildcard `*` default rule as fallback

## Why this layout

- Fine-grained paths ensure the right people are pinged for the right code areas
- The wildcard default catches anything not explicitly listed
- No GitHub teams are defined in Safrochain-Org yet (only `@danbaruka` is an org member); individual handles are used until teams are created

## Acceptance criteria

- [x] No GitHub handles outside the Safrochain-Org org remain in CODEOWNERS
- [x] PR review requests route to Safrochain maintainers
- [x] Granular rules exist for custom modules, CI, and docs

## Related

- Fixes #36