### PR TITLE
chore(codeowners): update CODEOWNERS to Safrochain maintainer handles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,20 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
 
-* @JakeHartnell @dimiandre @niilptr @vexxvakan
+# Default owners for everything
+*                       @Safrochain-Org/maintainers
+
+# Custom modules
+/x/clock/               @Safrochain-Org/core
+/x/cw-hooks/            @Safrochain-Org/core
+/x/drip/                @Safrochain-Org/core
+/x/feepay/              @Safrochain-Org/core
+/x/feeshare/            @Safrochain-Org/core
+/x/globalfee/           @Safrochain-Org/core
+/x/tokenfactory/        @Safrochain-Org/core
+/x/wrappers/            @Safrochain-Org/core
+
+# App wiring and consensus
+/app/                   @Safrochain-Org/core
+
+# Build / CI / release
+/.github/              @Safrochain-Org/core


### PR DESCRIPTION
## Summary

Fixes #36

The current CODEOWNERS references non-Safrochain handles that appear to be leftover from an upstream fork. This prevents Safrochain maintainers from being auto-requested on PRs.

## Changes

- Replaced wildcard entry `* @JakeHartnell @dimiandre @niilptr @vexxvakan` with path-based rules using @Safrochain-Org teams
- Added per-module path rules for each custom module (x/clock, x/cw-hooks, x/drip, x/feepay, x/feeshare, x/globalfee, x/tokenfactory, x/wrappers)
- Added /app/ and /.github/ path rules

## Related issue

Closes #36
